### PR TITLE
fix NPE when /dump run without arguments

### DIFF
--- a/src/main/java/nallar/tickprofiler/minecraft/commands/DumpCommand.java
+++ b/src/main/java/nallar/tickprofiler/minecraft/commands/DumpCommand.java
@@ -50,7 +50,9 @@ public class DumpCommand extends Command {
 		if (world == null) {
 			sendChat(commandSender, "Usage: /dump x y z [world=currentworld]");
 		}
-		sendChat(commandSender, dump(new TableFormatter(commandSender), world, x, y, z, commandSender instanceof Entity ? 35 : 70).toString());
+		else {
+			sendChat(commandSender, dump(new TableFormatter(commandSender), world, x, y, z, commandSender instanceof Entity ? 35 : 70).toString());
+		}	
 	}
 
 	public static TableFormatter dump(TableFormatter tf, World world, int x, int y, int z, int maxLen) {


### PR DESCRIPTION
This should fix the following undesirable behavior:

<pre>
/dump
[08:58:26] [Server thread/INFO] [TickProfiler]:
Usage: /dump x y z [world=currentworld]
[08:58:26] [Server thread/INFO]: An unknown error occurred while attempting to perform this command
[08:58:26] [Server thread/ERROR]: Couldn't process command: 'dump'
java.lang.NullPointerException
        at nallar.tickprofiler.minecraft.commands.DumpCommand.dump(DumpCommand.java:59) ~[DumpCommand.class:?]
        at nallar.tickprofiler.minecraft.commands.DumpCommand.processCommand(DumpCommand.java:53) ~[DumpCommand.class:?]
        at nallar.tickprofiler.minecraft.commands.Command.func_71515_b(Command.java:42) ~[Command.class:?]
        at net.minecraft.command.CommandHandler.func_71556_a(CommandHandler.java:94) [z.class:?]
        at net.minecraft.server.dedicated.DedicatedServer.func_71333_ah(DedicatedServer.java:370) [lt.class:?]
        at net.minecraft.server.dedicated.DedicatedServer.func_71190_q(DedicatedServer.java:335) [lt.class:?]
        at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:547) [MinecraftServer.class:?]
        at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:427) [MinecraftServer.class:?]
        at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685) [li.class:?]
</pre>

Encountered in <a href="https://feedthebeast.atlassian.net/wiki/display/PML/FTB+Resurrection+1.0.0">FTB Resurrection 1.0.0</a> (FTBServer-1.7.10-1263.jar, minecraft_server.1.7.10.jar)